### PR TITLE
Add CLI version test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "bin": {
     "yong": "yong.js"
+  },
+  "scripts": {
+    "test": "node test/cli.test.js"
   }
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { execFile } = require('child_process');
+const { version } = require('../package.json');
+
+execFile('node', ['./yong.js', '--version'], (error, stdout, stderr) => {
+  if (error) throw error;
+  try {
+    assert.strictEqual(stdout.trim(), version);
+    console.log('ok');
+  } catch (e) {
+    console.error('Version mismatch:', stdout.trim(), '!=', version);
+    throw e;
+  }
+});

--- a/yong.js
+++ b/yong.js
@@ -1,11 +1,18 @@
 #!/usr/bin/env node
 
+var pkg = require('./package.json');
+
+if (process.argv.indexOf('--version') !== -1 || process.argv.indexOf('-V') !== -1) {
+    console.log(pkg.version);
+    process.exit(0);
+}
+
 var command = require('commander');
 var request = require('request');
 var chalk = require('chalk');
 
 command
-    .version('0.0.1')
+    .version(pkg.version)
     .usage('<keywords>')
     .option('-b, --browser [broswer]', 'Filter by the browser')
     .parse(process.argv);


### PR DESCRIPTION
## Summary
- add minimal early version check in `yong.js` to run without deps when only `--version` is used
- add CLI integration test using `child_process.execFile`
- provide npm test script to run the integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402b901a10832f932ea4b0a1a87a16