### PR TITLE
Fix GitHub typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install yong -g
 
 I set up a simple server with nodejs and [jae](http://jae.jd.com/).
 
-The data is fetched from [ghithub/caniuse](https://github.com/Fyrd/caniuse).
+The data is fetched from [github/caniuse](https://github.com/Fyrd/caniuse).
 
 Check a css property.
 


### PR DESCRIPTION
## Summary
- correct link text in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68402b8de770832fa4b3d5b03e420c9a