### PR TITLE
Fix browser option spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ y x  means you can use, but you need to add a prefix like `-moz-`,`-webkit-`,`-o
 $ yong border-radius -b ie
 ```
 
+Use the `-b, --browser [browser]` option to limit results to a specific browser.
+
 ![ ](http://www.skylerzhang.com/assets/images/yong-b.jpg)
 
 ```

--- a/yong.js
+++ b/yong.js
@@ -7,7 +7,7 @@ var chalk = require('chalk');
 command
     .version('0.0.1')
     .usage('<keywords>')
-    .option('-b, --browser [broswer]', 'Filter by the browser')
+    .option('-b, --browser [browser]', 'Filter by the browser')
     .parse(process.argv);
 
 if(!command.args.length) {


### PR DESCRIPTION
## Summary
- correct browser option name in the CLI
- document browser option usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68402b901408832fb429c758945fb13f